### PR TITLE
Move active_support/deprecation to spec_helper

### DIFF
--- a/lib/xero.rb
+++ b/lib/xero.rb
@@ -1,5 +1,4 @@
 require 'active_attr'
-require 'active_support/deprecation'
 require 'active_support/core_ext'
 require 'active_support/inflection_config'
 require 'oauth'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'bundler/setup'
+require 'active_support/deprecation'
 require 'active_attr/rspec'
 require 'faker'
 require 'xero'


### PR DESCRIPTION
As we discussed, I moved the requiring of `active_support/deprecation` to `spec_helper.rb`